### PR TITLE
Bugfix: errors using short names of methods and functionals

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2024.10.15: Bugfix: errors using short names of methods and functionals
+    * There were bugs in the code that caused errors when using short names, e.g. "HF"
+      or "CCD" for the method, or e.g. "B3LYP" for the density fnctional.
+      
 2024.10.10: Enhancement: added sempiempirical methods
     * Added the various semiempirical methods supported by Gaussian so they can be used
       from SEAMM.

--- a/gaussian_step/energy.py
+++ b/gaussian_step/energy.py
@@ -85,6 +85,24 @@ class Energy(Substep):
                 functional = P["functional"]
             else:
                 functional = P["advanced_functional"]
+            found = functional in gaussian_step.dft_functionals
+            if not found:
+                # Might be first part of name, or Gaussian-encoded name
+                for _key, _data in gaussian_step.dft_functionals.items():
+                    if functional == _key.split(":")[0].strip():
+                        functional = _key
+                        found = True
+                        break
+            if not found:
+                # Might be the internal Gaussian name
+                for _key, _data in gaussian_step.dft_functionals.items():
+                    if functional == _data["name"]:
+                        functional = _key
+                        found = True
+                        break
+            if not found:
+                raise ValueError(f"Don't recognize functional '{functional}'")
+
             basis = P["basis"]
             text = f"{calculation} using {method} using {functional}"
             if (
@@ -234,6 +252,24 @@ class Energy(Substep):
                 functional = P["functional"]
             else:
                 functional = P["advanced_functional"]
+            found = functional in gaussian_step.dft_functionals
+            if not found:
+                # Might be first part of name, or Gaussian-encoded name
+                for _key, _data in gaussian_step.dft_functionals.items():
+                    if functional == _key.split(":")[0].strip():
+                        functional = _key
+                        found = True
+                        break
+            if not found:
+                # Might be the internal Gaussian name
+                for _key, _data in gaussian_step.dft_functionals.items():
+                    if functional == _data["name"]:
+                        functional = _key
+                        found = True
+                        break
+            if not found:
+                raise ValueError(f"Don't recognize functional '{functional}'")
+
             functional_data = gaussian_step.dft_functionals[functional]
             if restricted:
                 if multiplicity == 1:
@@ -405,10 +441,10 @@ class Energy(Substep):
                 method = method_data["method"]
             else:
                 # See if it matches the keyword part
-                for key, mdata in gaussian_step.methods.items():
-                    if method_string == mdata["method"]:
-                        method_string = key
-                        method_data = mdata
+                for _key, _mdata in gaussian_step.methods.items():
+                    if method_string == _mdata["method"]:
+                        method_string = _key
+                        method_data = _mdata
                         method = method_data["method"]
                         break
                 else:


### PR DESCRIPTION
* There were bugs in the code that caused errors when using short names, e.g. "HF" or "CCD" for the method, or e.g. "B3LYP" for the density functional.