### PR TITLE
Added an option to save the structure in the standard orientation.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,15 @@
 =======
 History
 =======
+2025.1.29: Added an option to save the structure in the standard orientation.
+    * Added an option to save the structure in the standard orientation, which is
+      the orientation used by Gaussian for the calculations. This is useful for
+      visualizing the structure, and is also the orientation for e.g. the calculated
+      orbitals.
+    * Fixed a bug in displaying the structure with the orbitals or density. The sructure
+      is now always in the standard orientation, regardless of the option above, as it
+      must be since the orbitals and density are calculated in the standard orientation.
+    
 2025.1.5: Added PBErev, HSE06, PBE0 and PBE0rev energies for thermochemistry
     * Added the atom energies for the 6-31G and 6-311G basis set families for the
       PBErev (PBEhPBE), HSE06 (HSEH1PBE), PBE0 (PBE1PBE), and PBE0rev (PBEH1PBE) density

--- a/gaussian_step/energy_parameters.py
+++ b/gaussian_step/energy_parameters.py
@@ -218,6 +218,15 @@ class EnergyParameters(seamm.Parameters):
                 "Whether to use the calculated bond orders to update the structure"
             ),
         },
+        "save standard orientation": {
+            "default": "yes",
+            "kind": "boolean",
+            "default_units": "",
+            "enumeration": ("yes", "no"),
+            "format_string": "s",
+            "description": "Save standard orientation:",
+            "help_text": "Keep the standard orientation rather than input orientation.",
+        },
         "print basis set": {
             "default": "no",
             "kind": "boolean",

--- a/gaussian_step/substep.py
+++ b/gaussian_step/substep.py
@@ -871,7 +871,7 @@ class Substep(seamm.Node):
 
         # Any requested orbitals
         if P["orbitals"]:
-            n_orbitals = data["nmo"]
+            n_orbitals = data["NMO"]
             # and work out the orbitals
             txt = P["selected orbitals"]
             for spin, homo in enumerate(data["homos"]):

--- a/gaussian_step/tk_energy.py
+++ b/gaussian_step/tk_energy.py
@@ -126,7 +126,12 @@ class TkEnergy(seamm.TkNode):
         )
         row = 0
         widgets = []
-        for key in ("structure handling", "system name", "configuration name"):
+        for key in (
+            "save standard orientation",
+            "structure handling",
+            "system name",
+            "configuration name",
+        ):
             self[key] = P[key].widget(sframe)
             self[key].grid(row=row, column=0, sticky=tk.EW)
             widgets.append(self[key])


### PR DESCRIPTION
* Added an option to save the structure in the standard orientation, which is the orientation used by Gaussian for the calculations. This is useful for visualizing the structure, and is also the orientation for e.g. the calculated orbitals.
* Fixed a bug in displaying the structure with the orbitals or density. The sructure is now always in the standard orientation, regardless of the option above, as it must be since the orbitals and density are calculated in the standard orientation.